### PR TITLE
Fix: 안드로이드 http 요청권한 허용

### DIFF
--- a/frontend/android/app/src/main/AndroidManifest.xml
+++ b/frontend/android/app/src/main/AndroidManifest.xml
@@ -1,8 +1,16 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- ✅ 인터넷 권한 추가 -->
+    <uses-permission android:name="android.permission.INTERNET" />
+
+    <!-- ✅ 네트워크 상태 확인 권한 (필요할 경우) -->
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+
     <application
         android:label="frontend"
         android:name="${applicationName}"
-        android:icon="@mipmap/ic_launcher">
+        android:icon="@mipmap/ic_launcher"
+        android:usesCleartextTraffic="true"
+        >
         <activity
             android:name=".MainActivity"
             android:exported="true"


### PR DESCRIPTION
androidManifest.xml 파일 수정
- android에서는 기본적으로 https만 요청을 허용해서, http도 허용 가능하게 수정합니다~