### PR TITLE
(#82)fe feat/jwt token

### DIFF
--- a/frontend/lib/screens/Login.dart
+++ b/frontend/lib/screens/Login.dart
@@ -22,6 +22,8 @@ class Login extends StatefulWidget {
 
 class LoginState extends State<Login> {
   final _formkey = GlobalKey<FormState>();
+  late SharedPreferences sharedPreferences;
+  bool logincheck = false;
   final FlutterSecureStorage secureStorage = const FlutterSecureStorage();
   bool _isPasswordVisible = false;
 
@@ -98,48 +100,139 @@ class LoginState extends State<Login> {
           crossAxisAlignment: CrossAxisAlignment.center,
           children: [
             Spacer(),
-            Text(
-              '로그인',
-              style: TextStyle(fontSize: 22, fontWeight: FontWeight.w600),
-            ),
-            SizedBox(height: 30),
-            Form(
-              key: _formkey,
-              child: Column(
-                children: [
-                  TextFormField(
-                    decoration: InputDecoration(hintText: "이메일"),
-                    onChanged: (value) => email = value,
-                  ),
-                  SizedBox(height: 10),
-                  TextFormField(
-                    obscureText: !_isPasswordVisible,
-                    decoration: InputDecoration(
-                      hintText: "비밀번호",
-                      suffixIcon: IconButton(
-                        onPressed: () {
-                          setState(() {
-                            _isPasswordVisible = !_isPasswordVisible;
-                          });
-                        },
-                        icon: Icon(_isPasswordVisible ? Icons.visibility : Icons.visibility_off),
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  '로그인',
+                  style: TextStyle(fontSize: 22, fontWeight: FontWeight.w600),
+                ),
+                SizedBox(height: 30),
+                Form(
+                  key: _formkey,
+                  child: Column(
+                    children: [
+                      SizedBox(
+                        width: 323,
+                        child: TextFormField(
+                          decoration: InputDecoration(
+                            hintText: "이메일",
+                            hintStyle: TextStyle(fontSize: 12),
+                            focusedBorder: UnderlineInputBorder(
+                              borderSide: BorderSide(color: Colors.grey),
+                            ),
+                          ),
+                          onChanged: (value) {
+                            email = value; // 이메일 값 저장
+                          },
+                        ),
                       ),
-                    ),
-                    onChanged: (value) => password = value,
+                      SizedBox(height: 10),
+                      SizedBox(
+                        width: 323,
+                        child: TextFormField(
+                          obscureText: !_isPasswordVisible,
+                          decoration: InputDecoration(
+                              hintText: "비밀번호",
+                              hintStyle: TextStyle(fontSize: 12),
+                              focusedBorder: UnderlineInputBorder(
+                                borderSide: BorderSide(color: Colors.grey),
+                              ),
+                              suffixIcon: IconButton(
+                                  onPressed: () {
+                                    setState(() {
+                                      _isPasswordVisible = !_isPasswordVisible;
+                                    });
+                                  },
+                                  icon: Icon(
+                                    _isPasswordVisible
+                                        ? Icons.visibility
+                                        : Icons.visibility_off,
+                                    color: Color(0xFFC1C7D0),
+                                  ))),
+                          onChanged: (value) {
+                            password = value; // 비밀번호 값 저장
+                          },
+                        ),
+                      ),
+                      SizedBox(height: 40),
+                      TextButton(
+                        onPressed: () {
+                          if (_formkey.currentState!.validate()) {
+                            login(); // 로그인 함수 호출
+                          }
+                        },
+                        style: TextButton.styleFrom(
+                          backgroundColor: Color(0xFF878CEF),
+                          minimumSize: Size(352, 45),
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(12),
+                          ),
+                        ),
+                        child: Text(
+                          "로그인",
+                          style: TextStyle(
+                              fontSize: 14,
+                              color: Colors.white,
+                              fontWeight: FontWeight.w700),
+                        ),
+                      ),
+                      SizedBox(height: 15),
+                      GestureDetector(
+                        child: Text(
+                          '비밀번호를 잊어버리셨나요?',
+                          style: TextStyle(
+                            fontSize: 12,
+                            color: Color(0xFF888888),
+                            decoration: TextDecoration.underline,
+                          ),
+                        ),
+                      ),
+                    ],
                   ),
-                  SizedBox(height: 40),
-                  TextButton(
-                    onPressed: () {
-                      if (_formkey.currentState!.validate()) {
-                        login();
-                      }
-                    },
-                    child: Text("로그인"),
-                  ),
-                ],
-              ),
+                ),
+              ],
             ),
             Spacer(),
+            Center(
+                child: Column(
+                  children: [
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        Text(
+                          '아직 계정이 없으신가요? ',
+                          style: TextStyle(
+                            fontSize: 14,
+                            color: Color(0xFFAAAAAA),
+                          ),
+                        ),
+                        GestureDetector(
+                          child: Text(
+                            '회원가입',
+                            style:
+                            TextStyle(color: Color(0xFF878CEF), fontSize: 14),
+                          ),
+                          onTap: () {
+                            Get.to(() => Signup());
+                          },
+                        )
+                      ],
+                    ),
+                    SizedBox(
+                      height: 20,
+                    ),
+                    GestureDetector(
+                      child: Text(
+                        '건너뛰기',
+                        style: TextStyle(fontSize: 12, color: Color(0xFFCCCCCC)),
+                      ),
+                      onTap: () {
+                        Get.to(() => HomeScreen());
+                      },
+                    )
+                  ],
+                )),
           ],
         ),
       ),

--- a/frontend/lib/screens/Login.dart
+++ b/frontend/lib/screens/Login.dart
@@ -4,8 +4,8 @@ import 'package:frontend/screens/signup.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:get/get.dart';
 import 'package:http/http.dart' as http;
-import 'package:flutter_dotenv/flutter_dotenv.dart'; // dotenv 패키지 추가
-import 'package:flutter_secure_storage/flutter_secure_storage.dart'; // Secure Storage 추가
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'dart:convert';
 
 void main() async {
@@ -22,22 +22,16 @@ class Login extends StatefulWidget {
 
 class LoginState extends State<Login> {
   final _formkey = GlobalKey<FormState>();
-  final FlutterSecureStorage secureStorage = const FlutterSecureStorage(); // Secure Storage 인스턴스 생성
-  late SharedPreferences sharedPreferences;
-  bool logincheck = false;
+  final FlutterSecureStorage secureStorage = const FlutterSecureStorage();
   bool _isPasswordVisible = false;
 
-  late String email = ''; // 이메일 초기화
-  late String password = ''; // 비밀번호 초기화
+  late String email = '';
+  late String password = '';
 
   Future<void> login() async {
     final baseUrl = dotenv.env['API_BASE_URL'];
     if (baseUrl == null) {
-      Get.snackbar(
-        "오류",
-        "API_BASE_URL 환경 변수가 설정되지 않았습니다.",
-        snackPosition: SnackPosition.TOP,
-      );
+      Get.snackbar("오류", "API_BASE_URL 환경 변수가 설정되지 않았습니다.", snackPosition: SnackPosition.TOP);
       return;
     }
 
@@ -61,43 +55,34 @@ class LoginState extends State<Login> {
           String? jwtToken = _extractJwtFromCookie(cookies);
 
           if (jwtToken != null) {
-            // JWT 토큰을 flutter_secure_storage에 저장
             await secureStorage.write(key: "jwt_token", value: jwtToken);
             print("JWT 저장 완료: $jwtToken");
 
-            Get.snackbar("로그인 성공", "홈 화면으로 이동합니다.",
-                snackPosition: SnackPosition.TOP);
+            Get.snackbar("로그인 성공", "홈 화면으로 이동합니다.", snackPosition: SnackPosition.TOP);
             Get.to(() => HomeScreen());
             return;
           }
         }
 
-        Get.snackbar("로그인 실패", "JWT 토큰을 찾을 수 없습니다.",
-            snackPosition: SnackPosition.TOP);
+        Get.snackbar("로그인 실패", "JWT 토큰을 찾을 수 없습니다.", snackPosition: SnackPosition.TOP);
       } else {
-        Get.snackbar(
-          "로그인 실패",
-          '로그인에 실패하였습니다: ${response.body}',
-          snackPosition: SnackPosition.TOP,
-        );
-        print("서버와 통신 실패 (${response.statusCode})");
+        Get.snackbar("로그인 실패", '로그인에 실패하였습니다: ${response.body}', snackPosition: SnackPosition.TOP);
       }
     } catch (e) {
-      Get.snackbar(
-        "네트워크 에러",
-        "서버와 연결할 수 없습니다.",
-        snackPosition: SnackPosition.TOP,
-      );
+      Get.snackbar("네트워크 에러", "서버와 연결할 수 없습니다.", snackPosition: SnackPosition.TOP);
       print('문제 : $e');
     }
   }
 
-  /// 🔹 쿠키에서 JWT 토큰 추출하는 함수
   String? _extractJwtFromCookie(String cookie) {
     List<String> cookies = cookie.split("; ");
     for (String c in cookies) {
-      if (c.startsWith("ACCESS_TOKEN=")) { // 기존 jwt= 에서 ACCESS_TOKEN=으로 변경
-        return c.split("=")[1]; // JWT 토큰 값 추출
+      if (c.startsWith("ACCESS_TOKEN=")) {
+        String token = c.split("=")[1]; // JWT + REFRESH_TOKEN 포함 가능
+        if (token.contains(",")) {
+          token = token.split(",")[0]; // ✅ 첫 번째 값(JWT)만 저장
+        }
+        return token;
       }
     }
     return null;
@@ -113,88 +98,46 @@ class LoginState extends State<Login> {
           crossAxisAlignment: CrossAxisAlignment.center,
           children: [
             Spacer(),
-            Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  '로그인',
-                  style: TextStyle(fontSize: 22, fontWeight: FontWeight.w600),
-                ),
-                SizedBox(height: 30),
-                Form(
-                  key: _formkey,
-                  child: Column(
-                    children: [
-                      SizedBox(
-                        width: 323,
-                        child: TextFormField(
-                          decoration: InputDecoration(
-                            hintText: "이메일",
-                            hintStyle: TextStyle(fontSize: 12),
-                            focusedBorder: UnderlineInputBorder(
-                              borderSide: BorderSide(color: Colors.grey),
-                            ),
-                          ),
-                          onChanged: (value) {
-                            email = value;
-                          },
-                        ),
-                      ),
-                      SizedBox(height: 10),
-                      SizedBox(
-                        width: 323,
-                        child: TextFormField(
-                          obscureText: !_isPasswordVisible,
-                          decoration: InputDecoration(
-                              hintText: "비밀번호",
-                              hintStyle: TextStyle(fontSize: 12),
-                              focusedBorder: UnderlineInputBorder(
-                                borderSide: BorderSide(color: Colors.grey),
-                              ),
-                              suffixIcon: IconButton(
-                                  onPressed: () {
-                                    setState(() {
-                                      _isPasswordVisible = !_isPasswordVisible;
-                                    });
-                                  },
-                                  icon: Icon(
-                                    _isPasswordVisible
-                                        ? Icons.visibility
-                                        : Icons.visibility_off,
-                                    color: Color(0xFFC1C7D0),
-                                  ))),
-                          onChanged: (value) {
-                            password = value;
-                          },
-                        ),
-                      ),
-                      SizedBox(height: 40),
-                      TextButton(
-                        onPressed: () {
-                          if (_formkey.currentState!.validate()) {
-                            login();
-                          }
-                        },
-                        style: TextButton.styleFrom(
-                          backgroundColor: Color(0xFF878CEF),
-                          minimumSize: Size(352, 45),
-                          shape: RoundedRectangleBorder(
-                            borderRadius: BorderRadius.circular(12),
-                          ),
-                        ),
-                        child: Text(
-                          "로그인",
-                          style: TextStyle(
-                              fontSize: 14,
-                              color: Colors.white,
-                              fontWeight: FontWeight.w700),
-                        ),
-                      ),
-                      SizedBox(height: 15),
-                    ],
+            Text(
+              '로그인',
+              style: TextStyle(fontSize: 22, fontWeight: FontWeight.w600),
+            ),
+            SizedBox(height: 30),
+            Form(
+              key: _formkey,
+              child: Column(
+                children: [
+                  TextFormField(
+                    decoration: InputDecoration(hintText: "이메일"),
+                    onChanged: (value) => email = value,
                   ),
-                ),
-              ],
+                  SizedBox(height: 10),
+                  TextFormField(
+                    obscureText: !_isPasswordVisible,
+                    decoration: InputDecoration(
+                      hintText: "비밀번호",
+                      suffixIcon: IconButton(
+                        onPressed: () {
+                          setState(() {
+                            _isPasswordVisible = !_isPasswordVisible;
+                          });
+                        },
+                        icon: Icon(_isPasswordVisible ? Icons.visibility : Icons.visibility_off),
+                      ),
+                    ),
+                    onChanged: (value) => password = value,
+                  ),
+                  SizedBox(height: 40),
+                  TextButton(
+                    onPressed: () {
+                      if (_formkey.currentState!.validate()) {
+                        login();
+                      }
+                    },
+                    child: Text("로그인"),
+                  ),
+                ],
+              ),
             ),
             Spacer(),
           ],

--- a/frontend/lib/screens/my_resume_create_page.dart
+++ b/frontend/lib/screens/my_resume_create_page.dart
@@ -14,6 +14,7 @@ import 'resume/certificate_page.dart';
 import 'resume/language_page.dart';
 import 'my_resume_screen.dart'; // 추가된 import
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:frontend/utils/http_interceptor.dart';
 
 class MyResumeCreatePage extends StatefulWidget {
   const MyResumeCreatePage({Key? key}) : super(key: key);
@@ -46,13 +47,6 @@ class _MyResumeCreatePageState extends State<MyResumeCreatePage> {
     // 수정 요망
     const userId = "1";
     final url = Uri.parse('$baseUrl/api/v1/resume/create/$userId');
-
-    String? accessToken = await secureStorage.read(key: "jwt_token");
-    print("🔑 불러온 ACCESS_TOKEN: $accessToken");  // 🚀 이 값이 null 또는 빈 문자열인지 확인
-    if (accessToken == null) {
-      ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text('토큰이 없습니다. 다시 로그인해주세요.'), backgroundColor: Colors.red));
-      return;
-    }
 
     final List<Map<String, String>> formattedActivityExperience =
         activityExperience.map((experience) {
@@ -108,23 +102,25 @@ class _MyResumeCreatePageState extends State<MyResumeCreatePage> {
     };
 
     try {
-      final response = await http.post(
-        url,
-        headers: {
-          'Content-Type': 'application/json',
-          'Cookie': 'ACCESS_TOKEN=$accessToken; Path=/',
-        },
-        body: jsonEncode(requestBody),
-      );
+      final response = await HttpInterceptor().post(url, body: requestBody);
 
       if (response.statusCode == 200) {
-        ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text('이력서가 성공적으로 저장되었습니다!'), backgroundColor: Colors.green));
-        Navigator.push(context, MaterialPageRoute(builder: (context) => MyResumeScreen(resumeTitle: resumeTitle)));
+        ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+          content: Text('이력서가 성공적으로 저장되었습니다!'), backgroundColor: Colors.green,
+        ));
+        Navigator.push(
+          context,
+          MaterialPageRoute(builder: (context) => MyResumeScreen(resumeTitle: resumeTitle)),
+        );
       } else {
-        ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text('이력서 저장 실패: ${response.body}'), backgroundColor: Colors.red));
+        ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+          content: Text('이력서 저장 실패: ${response.body}'), backgroundColor: Colors.red,
+        ));
       }
     } catch (e) {
-      ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text('오류 발생: $e'), backgroundColor: Colors.red));
+      ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+        content: Text('오류 발생: $e'), backgroundColor: Colors.red,
+      ));
     }
   }
 

--- a/frontend/lib/screens/my_resume_create_page.dart
+++ b/frontend/lib/screens/my_resume_create_page.dart
@@ -13,6 +13,7 @@ import 'resume/award_page.dart';
 import 'resume/certificate_page.dart';
 import 'resume/language_page.dart';
 import 'my_resume_screen.dart'; // 추가된 import
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
 class MyResumeCreatePage extends StatefulWidget {
   const MyResumeCreatePage({Key? key}) : super(key: key);
@@ -22,6 +23,8 @@ class MyResumeCreatePage extends StatefulWidget {
 }
 
 class _MyResumeCreatePageState extends State<MyResumeCreatePage> {
+  final FlutterSecureStorage secureStorage = const FlutterSecureStorage();
+
   String resumeTitle = "";
   List<String> industryGroups = [];
   String jobDuty = "";
@@ -33,21 +36,23 @@ class _MyResumeCreatePageState extends State<MyResumeCreatePage> {
   List<Map<String, String>> certificates = [];
   List<Map<String, String>> languages = [];
 
-  Future<void> saveResumeWithToken(String accessToken) async {
+  Future<void> saveResume() async {
     final String? baseUrl = dotenv.env['API_BASE_URL'];
     if (baseUrl == null) {
-      print("Base URL is null. Check .env file.");
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(
-          content: Text('환경 변수를 확인해주세요.'),
-          backgroundColor: Colors.red,
-        ),
-      );
+      ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text('환경 변수를 확인해주세요.'), backgroundColor: Colors.red));
       return;
     }
 
+    // 수정 요망
     const userId = "1";
     final url = Uri.parse('$baseUrl/api/v1/resume/create/$userId');
+
+    String? accessToken = await secureStorage.read(key: "jwt_token");
+    print("🔑 불러온 ACCESS_TOKEN: $accessToken");  // 🚀 이 값이 null 또는 빈 문자열인지 확인
+    if (accessToken == null) {
+      ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text('토큰이 없습니다. 다시 로그인해주세요.'), backgroundColor: Colors.red));
+      return;
+    }
 
     final List<Map<String, String>> formattedActivityExperience =
         activityExperience.map((experience) {
@@ -103,51 +108,26 @@ class _MyResumeCreatePageState extends State<MyResumeCreatePage> {
     };
 
     try {
-      final response = await http
-          .post(
-            url,
-            headers: {
-              'Content-Type': 'application/json',
-              'Cookie': 'ACCESS_TOKEN=$accessToken; Path=/api/v1/auth',
-            },
-            body: jsonEncode(requestBody),
-          )
-          .timeout(const Duration(seconds: 30));
+      final response = await http.post(
+        url,
+        headers: {
+          'Content-Type': 'application/json',
+          'Cookie': 'ACCESS_TOKEN=$accessToken; Path=/',
+        },
+        body: jsonEncode(requestBody),
+      );
 
       if (response.statusCode == 200) {
-        print("이력서 저장 성공!");
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(
-            content: Text('이력서가 성공적으로 저장되었습니다!'),
-            backgroundColor: Colors.green,
-          ),
-        );
-        Navigator.push(
-          context,
-          MaterialPageRoute(
-              builder: (context) => const MyResumeScreen(
-                    resumeTitle: '',
-                  )),
-        );
+        ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text('이력서가 성공적으로 저장되었습니다!'), backgroundColor: Colors.green));
+        Navigator.push(context, MaterialPageRoute(builder: (context) => MyResumeScreen(resumeTitle: resumeTitle)));
       } else {
-        print("이력서 저장 실패: ${response.body}");
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text('이력서 저장 실패: ${response.body}'),
-            backgroundColor: Colors.red,
-          ),
-        );
+        ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text('이력서 저장 실패: ${response.body}'), backgroundColor: Colors.red));
       }
     } catch (e) {
-      print('오류 발생: $e');
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text('오류 발생: $e'),
-          backgroundColor: Colors.red,
-        ),
-      );
+      ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text('오류 발생: $e'), backgroundColor: Colors.red));
     }
   }
+
 
   @override
   Widget build(BuildContext context) {
@@ -395,9 +375,10 @@ class _MyResumeCreatePageState extends State<MyResumeCreatePage> {
                 ),
               );
             } else {
-              final String? accessToken = dotenv.env['ACCESS_TOKEN'];
+              final String? accessToken = await secureStorage.read(key: "jwt_token");
+              print("🔑 불러온 ACCESS_TOKEN: $accessToken");  // 🚀 정상적으로 불러오는지 확인
               if (accessToken != null && accessToken.isNotEmpty) {
-                await saveResumeWithToken(accessToken);
+                await saveResume();
               } else {
                 ScaffoldMessenger.of(context).showSnackBar(
                   const SnackBar(

--- a/frontend/lib/screens/my_resume_screen.dart
+++ b/frontend/lib/screens/my_resume_screen.dart
@@ -37,14 +37,7 @@ class _MyResumeScreenState extends State<MyResumeScreen> {
     final url = Uri.parse('$baseUrl/api/v1/resume/user/$userId');
 
     try {
-      final accessToken = dotenv.env['ACCESS_TOKEN'];
-
-      final response = await http.get(
-        url,
-        headers: {
-          'Authorization': 'Bearer $accessToken',
-        },
-      );
+      final response = await HttpInterceptor().get(url);
 
       print('Response status code: ${response.statusCode}');
       if (response.statusCode == 200) {
@@ -91,14 +84,7 @@ class _MyResumeScreenState extends State<MyResumeScreen> {
     final url = Uri.parse('$baseUrl/api/v1/resume/delete/$userId/$resumeId');
 
     try {
-      final accessToken = dotenv.env['ACCESS_TOKEN'];
-
-      final response = await http.delete(
-        url,
-        headers: {
-          'Authorization': 'Bearer $accessToken',
-        },
-      );
+      final response = await HttpInterceptor().delete(url);
 
       if (response.statusCode == 200) {
         print('이력서 삭제 성공: $resumeId');
@@ -122,15 +108,7 @@ class _MyResumeScreenState extends State<MyResumeScreen> {
     print('대표 이력서 설정 요청 URL: $url');
 
     try {
-      final accessToken = dotenv.env['ACCESS_TOKEN'];
-
-      final response = await http.post(
-        url,
-        headers: {
-          'Authorization': 'Bearer $accessToken',
-          'Content-Type': 'application/json',
-        },
-      );
+      final response = await HttpInterceptor().post(url);
 
       if (response.statusCode == 200) {
         print('대표 이력서 설정 성공: $resumeId');

--- a/frontend/lib/screens/my_resume_screen.dart
+++ b/frontend/lib/screens/my_resume_screen.dart
@@ -9,6 +9,8 @@ import 'my_resume_create_page.dart';
 import 'widgets/my_resume_empty_widget.dart';
 import 'components/resume_PopupMenu_Btn.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:frontend/utils/http_interceptor.dart';
+
 
 class MyResumeScreen extends StatefulWidget {
   const MyResumeScreen({Key? key, required this.resumeTitle}) : super(key: key);

--- a/frontend/lib/utils/http_interceptor.dart
+++ b/frontend/lib/utils/http_interceptor.dart
@@ -1,0 +1,91 @@
+import 'package:http/http.dart' as http;
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'dart:convert';
+
+class HttpInterceptor {
+  static final HttpInterceptor _instance = HttpInterceptor._internal();
+  final FlutterSecureStorage secureStorage = const FlutterSecureStorage();
+
+  factory HttpInterceptor() {
+    return _instance;
+  }
+
+  HttpInterceptor._internal();
+
+  /// ✅ HTTP 요청 시 자동으로 `ACCESS_TOKEN`을 가져와 헤더에 추가하는 메서드
+  Future<http.Response> get(Uri url) async {
+    final String? accessToken = await secureStorage.read(key: "jwt_token");
+
+    if (accessToken == null || accessToken.isEmpty) {
+      throw Exception("🚨 토큰이 없습니다. 다시 로그인해주세요.");
+    }
+
+    print("🔑 요청에 사용될 ACCESS_TOKEN: $accessToken");
+
+    return http.get(
+      url,
+      headers: {
+        'Authorization': 'Bearer $accessToken',
+        'Cookie': 'ACCESS_TOKEN=$accessToken',
+      },
+    );
+  }
+
+  Future<http.Response> post(Uri url, {Map<String, dynamic>? body}) async {
+    final String? accessToken = await secureStorage.read(key: "jwt_token");
+
+    if (accessToken == null || accessToken.isEmpty) {
+      throw Exception("🚨 토큰이 없습니다. 다시 로그인해주세요.");
+    }
+
+    print("🔑 요청에 사용될 ACCESS_TOKEN: $accessToken");
+
+    return http.post(
+      url,
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': 'Bearer $accessToken',
+        'Cookie': 'ACCESS_TOKEN=$accessToken',
+      },
+      body: body != null ? jsonEncode(body) : null, // 🚀 JSON 변환 추가,
+    );
+  }
+
+  Future<http.Response> put(Uri url, {Object? body}) async {
+    final String? accessToken = await secureStorage.read(key: "jwt_token");
+
+    if (accessToken == null || accessToken.isEmpty) {
+      throw Exception("🚨 토큰이 없습니다. 다시 로그인해주세요.");
+    }
+
+    print("🔑 요청에 사용될 ACCESS_TOKEN: $accessToken");
+
+    return http.put(
+      url,
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': 'Bearer $accessToken',
+        'Cookie': 'ACCESS_TOKEN=$accessToken',
+      },
+      body: body,
+    );
+  }
+
+  Future<http.Response> delete(Uri url) async {
+    final String? accessToken = await secureStorage.read(key: "jwt_token");
+
+    if (accessToken == null || accessToken.isEmpty) {
+      throw Exception("🚨 토큰이 없습니다. 다시 로그인해주세요.");
+    }
+
+    print("🔑 요청에 사용될 ACCESS_TOKEN: $accessToken");
+
+    return http.delete(
+      url,
+      headers: {
+        'Authorization': 'Bearer $accessToken',
+        'Cookie': 'ACCESS_TOKEN=$accessToken',
+      },
+    );
+  }
+}

--- a/frontend/linux/flutter/generated_plugin_registrant.cc
+++ b/frontend/linux/flutter/generated_plugin_registrant.cc
@@ -6,6 +6,10 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <flutter_secure_storage_linux/flutter_secure_storage_linux_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
+  g_autoptr(FlPluginRegistrar) flutter_secure_storage_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "FlutterSecureStorageLinuxPlugin");
+  flutter_secure_storage_linux_plugin_register_with_registrar(flutter_secure_storage_linux_registrar);
 }

--- a/frontend/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/frontend/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,6 +5,12 @@
 import FlutterMacOS
 import Foundation
 
+import flutter_secure_storage_macos
+import path_provider_foundation
+import shared_preferences_foundation
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  FlutterSecureStoragePlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStoragePlugin"))
+  PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
+  SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
 }

--- a/frontend/pubspec.yaml
+++ b/frontend/pubspec.yaml
@@ -30,6 +30,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  flutter_secure_storage: ^9.0.0
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.

--- a/frontend/windows/flutter/generated_plugin_registrant.cc
+++ b/frontend/windows/flutter/generated_plugin_registrant.cc
@@ -6,6 +6,9 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <flutter_secure_storage_windows/flutter_secure_storage_windows_plugin.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
+  FlutterSecureStorageWindowsPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("FlutterSecureStorageWindowsPlugin"));
 }


### PR DESCRIPTION
Flutter 처음 깔아서 시작해본거라 미숙한 점 이해 부탁드립니다

1. flutter_secure_storage를 이용하여 login 시 쿠키로 제공되는 jwt 토큰 (ACCESS_TOKEN)을 저장하는 방식으로 전환

2.  http_interceptor.dart를 이용하여 get, post, put, delete 요청 시 flutter_secure_storage에 저장된 ACCESS_TOKEN를 헤더 cookie로 함께 전송하여 요청 권한 췤 (기존 .env에서 테스트로 값 주입하는 방식 제거)

3. 이력서 기능 완벽 교체 완료

손보면서 느낀 추가로 고쳐야할 점 (fix 부탁드립니다)

1. const userId = "1"; 로 지금 임의의 userId를 고정으로 주고 있는데 로그인한 사용자의 userid를 어떻게 받아올 것인가? 
2. 백엔드에서 로그인 시 쿠키에 같이 저장해서 드릴까여?
